### PR TITLE
allow explicitly unsanitized ruby lines when in :escape_html mode

### DIFF
--- a/Syntaxes/Ruby Haml.tmLanguage
+++ b/Syntaxes/Ruby Haml.tmLanguage
@@ -354,7 +354,7 @@
 		<key>rubyline</key>
 		<dict>
 			<key>begin</key>
-			<string>=|-|~</string>
+			<string>=|!=|-|~</string>
 			<key>contentName</key>
 			<string>source.ruby.embedded.haml</string>
 			<key>end</key>


### PR DESCRIPTION
This change facilitates syntax coloring for ruby lines on codebases using the :escape_html option.  When that's set, many if not most ruby lines start with "!=" instead of "=".
