### PR TITLE
Same-level indented soft wrap for Haml

### DIFF
--- a/Preferences/Indented Soft Wrap.tmPreferences
+++ b/Preferences/Indented Soft Wrap.tmPreferences
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>name</key>
+	<string>Indented Soft Wrap</string>
+	<key>scope</key>
+	<string>text.haml</string>
+	<key>settings</key>
+	<dict>
+		<key>indentedSoftWrap</key>
+		<dict>
+			<key>format</key>
+			<string>$0</string>
+			<key>match</key>
+			<string>\A[ \t]*</string>
+		</dict>
+	</dict>
+	<key>uuid</key>
+	<string>3DA2A57F-4A36-497E-B240-7BB0530F1B9C</string>
+</dict>
+</plist>


### PR DESCRIPTION
TM2 indented soft wrap just makes too much sense for Haml, it really ought to be the default.
### After

![screen shot 2013-07-18 at 14 50 18](https://f.cloud.github.com/assets/430/821892/67dbee3e-efe3-11e2-9536-2144826d8edb.png)
### Before

![screen shot 2013-07-18 at 14 49 12](https://f.cloud.github.com/assets/430/821891/637a8ea4-efe3-11e2-9cd8-1f8872001cd7.png)
