### PR TITLE
Empty line in embedded coffee/js/css/scss breaks the block

### DIFF
--- a/Syntaxes/Ruby Haml.tmLanguage
+++ b/Syntaxes/Ruby Haml.tmLanguage
@@ -83,7 +83,7 @@
 			<key>begin</key>
 			<string>^(\s*):coffee(script)?$</string>
 			<key>end</key>
-			<string>^(?!\1\s)</string>
+			<string>^(?!\1\s|\s*\n)</string>
 			<key>name</key>
 			<string>source.coffee.embedded.filter.haml</string>
 			<key>patterns</key>
@@ -98,7 +98,7 @@
 			<key>begin</key>
 			<string>^(\s*):scss$</string>
 			<key>end</key>
-			<string>^(?!\1\s)</string>
+			<string>^(?!\1\s|\s*\n)</string>
 			<key>name</key>
 			<string>source.scss.embedded.filter.haml</string>
 			<key>patterns</key>
@@ -113,7 +113,7 @@
 			<key>begin</key>
 			<string>^(\s*):css$</string>
 			<key>end</key>
-			<string>^(?!\1\s)</string>
+			<string>^(?!\1\s|\s*\n)</string>
 			<key>name</key>
 			<string>source.css.embedded.filter.haml</string>
 			<key>patterns</key>
@@ -128,7 +128,7 @@
 			<key>begin</key>
 			<string>^(\s*):javascript$</string>
 			<key>end</key>
-			<string>^(?!\1\s)</string>
+			<string>^(?!\1\s|\s*\n)</string>
 			<key>name</key>
 			<string>source.js.embedded.filter.haml</string>
 			<key>patterns</key>


### PR DESCRIPTION
An empty line broke a continuous coffeescript/javascript/css/scss block. 

Here is an example. Before the fix, the last line was not considered to be the same coffeescript block, thus not highlighted as coffeescript

(here UNDERSCORE as SPACES)

```
__:coffeescript
____$ ->
______$('#title').text('hello')

______$('#content').text('world)
```